### PR TITLE
Change syntax to standard ansible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,9 @@
 # Set up a simple sudoers file
 ---
 - name: Copying, Verifying and placing sudo file
-  template: 
-    src: sudoers.j2
-    dest: /etc/sudoers
-    owner: root
-    group: root
-    mode: 0440
-    validate: 'visudo -cf %s'
+  template: >
+    src=sudoers.j2
+    dest=/etc/sudoers
+    owner=root group=root mode=0440
+    validate='visudo -cf %s'
+


### PR DESCRIPTION
The format of the template line caused problems with CentOS for some reason. Having it in the key=value form fixes that.
