### PR TITLE
Add support for sudoers.d and allow alternative template of sudoers file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+meta/.galaxy_install_info

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,15 @@
 ---
+
+sudo_sudoers_template: sudoers.j2
+
+sudo_sudoers_dir: '/etc/sudoers.d'
+
 # Who has sudo access - use %foo for groups
 #sudo_sudoers:
 #  "user":
 #  "pass":
 #    nopassword: false
- 
+
 
 # The sudo defaults, please see documentation of sudo for specifics.
 sudo_defaults:
@@ -13,13 +18,13 @@ sudo_defaults:
   - secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # These are the sudo user defaults, If you add a user with these settings
-# the user will be able to sudo from all hosts, to all users using 
+# the user will be able to sudo from all hosts, to all users using
 # all commands without password prompts. you can offcourse change the
 # defaults here or override them on a per user basis.
 sudo_userdefaults:
   hosts: ALL
   asuser: ALL
-  asgroup: ALL 
+  asgroup: ALL
   nopassword: true
   commands: ALL
 
@@ -39,3 +44,5 @@ sudo_userdefaults:
 # Here you set runas aliases, defining a group of users someone may
 # run commands as, usable in the sudo users directive.
 # sudo_runasalias:
+
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -34,3 +34,4 @@ galaxy_info:
   categories:
   - system
 dependencies: []
+...

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Ensure the sudoers directory is present
   file: >
-        path="{{ sudo_sudoers_dir }}"
+        path="{{ sudo_sudoers_dir | mandatory }}"
         state='directory'
         owner='root'
         group='root'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,3 +22,12 @@
 
 - name: Ensure sudo group present
   group: name=sudo state=present system=yes
+
+- name: Ensure the sudoers directory is present
+  file: >
+        path="{{ sudo_sudoers_dir }}"
+        state='directory'
+        owner='root'
+        group='root'
+        mode=0700
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
 
 - name: Copying, Verifying and placing sudo file
   template: >
-    src=sudoers.j2
+    src="{{ sudo_sudoers_template | mandatory }}"
     dest=/etc/sudoers
     owner=root group=root mode=0440
     validate='visudo -cf %s'
-
+...

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -34,38 +34,44 @@ Runas_Alias {{name}} = {{alias}}
 {% endif %}
 
 # The users
-{% for sudoer, vars in sudo_sudoers.iteritems() -%}
-  {% set name = sudoer -%}
 
-{% if vars.asuser is defined -%}
-  {% set asuser = vars.asuser %}
-{% else -%}
-  {% set asuser = sudo_userdefaults.asuser %}
+{% if sudo_sudoers is defined %}
+  {% for sudoer, vars in sudo_sudoers.iteritems() -%}
+    {% set name = sudoer -%}
+
+    {% if vars.asuser is defined -%}
+      {% set asuser = vars.asuser %}
+    {% else -%}
+      {% set asuser = sudo_userdefaults.asuser %}
+    {% endif -%}
+
+    {% if vars.hosts is defined -%}
+      {% set hosts = vars.hosts %}
+    {% else -%}
+      {% set hosts = sudo_userdefaults.hosts %}
+    {% endif -%}
+
+    {% if vars.asgroup is defined -%}
+      {% set asgroup = vars.asgroup %}
+    {% else -%}
+      {% set asgroup = sudo_userdefaults.asgroup %}
+    {% endif -%}
+
+    {% if vars.nopassword is defined -%}
+      {% set nopassword = vars.nopassword %}
+    {% else -%}
+      {% set nopassword = sudo_userdefaults.nopassword %}
+    {% endif -%}
+
+    {% if vars.commands is defined -%}
+      {% set commands = vars.commands %}
+    {% else -%}
+      {%- set commands = sudo_userdefaults.commands %}
+    {% endif -%}
+
+    {{sudoer}} {{hosts}}=({{asuser}}) {{"NOPASSWD:" if nopassword else ""}}{{commands}}
+  {%- endfor %}
 {% endif -%}
 
-{% if vars.hosts is defined -%}
-  {% set hosts = vars.hosts %}
-{% else -%}
-  {% set hosts = sudo_userdefaults.hosts %}
-{% endif -%}
-
-{% if vars.asgroup is defined -%}
-  {% set asgroup = vars.asgroup %}
-{% else -%}
-  {% set asgroup = sudo_userdefaults.asgroup %}
-{% endif -%}
-
-{% if vars.nopassword is defined -%}
-  {% set nopassword = vars.nopassword %}
-{% else -%}
-  {% set nopassword = sudo_userdefaults.nopassword %}
-{% endif -%}
-
-{% if vars.commands is defined -%}
-  {% set commands = vars.commands %}
-{% else -%}
-  {%- set commands = sudo_userdefaults.commands %}
-{% endif -%}
-
-{{sudoer}} {{hosts}}=({{asuser}}) {{"NOPASSWD:" if nopassword else ""}}{{commands}}
-{% endfor %}
+## Read drop-in files from /etc/sudoers.d (the # here does not mean a comment)
+#includedir {{ sudo_sudoers_dir | mandatory }}


### PR DESCRIPTION
- Minor amends to formatting for legibility
- Allow users to designate their own template as base for sudoers
- Create sudoers.d dir at specified location and include in default template